### PR TITLE
fix: healthcheck makes it come up too slowly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,6 @@ env:
   # NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # Allow `--HEAD` flag when running tests against HEAD
-  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   tests:

--- a/docker-compose.phpmyadmin.yaml
+++ b/docker-compose.phpmyadmin.yaml
@@ -20,7 +20,6 @@ services:
     - HTTP_EXPOSE=8036:80
     - HTTPS_EXPOSE=8037:80
     healthcheck:
-      test: ["CMD", "curl", "-I", "-s", "-f", "http://localhost:80"]
       interval: 120s
       timeout: 2s
       retries: 1


### PR DESCRIPTION
## The Issue

With the healthcheck test in there it was taking forever to become ready.

## How This PR Solves The Issue

Remove the test from the healthcheck

## Manual Testing Instructions

```
ddev get https://github.com/ddev/ddev-phpmyadmin/tarball/20230721_less_healthcheck
ddev restart
```

It shouldn't wait forever to come up after it says "router started"

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

