### PR TITLE
fix: directly expose port on 8036 when router disabled, fixes #3

### DIFF
--- a/docker-compose.phpmyadmin-norouter.yaml
+++ b/docker-compose.phpmyadmin-norouter.yaml
@@ -1,0 +1,4 @@
+#ddev-generated
+# If omit_containers[ddev-router] then this file will be replaced
+# with another with a `ports` statement to directly expose port 80 to 8036
+services: {}

--- a/install.yaml
+++ b/install.yaml
@@ -4,4 +4,14 @@ name: phpmyadmin
 
 project_files:
 - docker-compose.phpmyadmin.yaml
+- docker-compose.phpmyadmin-norouter.yaml
 - commands/host/phpmyadmin
+
+post_install_actions:
+  - |
+    #ddev-description:If router disabled, directly expose port
+    #
+    if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
+      printf "#ddev-generated\nservices:\n  phpmyadmin:\n    ports:\n      - 8036:80\n" > docker-compose.phpmyadmin-norouter.yaml
+    fi
+


### PR DESCRIPTION
## The Issue

* #3

## How This PR Solves The Issue

* When `omit_containers[ddev-router]` create a docker-compose.phpmyadmin-norouter.yaml which exposes container port 80 as localhost port 8036
* On removal of the add-on, also remove the new file

## Manual Testing Instructions


With and without `omit_containers: [ddev-router]` try:
```
ddev get https://github.com/rfay/ddev-phpmyadmin/tarball/20230725_ports
ddev restart
```

This should work on Gitpod and Github Codespacees

## Automated Testing Overview

- [ ] Needs test

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

