### PR TITLE
Improve test to be less fragile about output, use github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,7 @@ permissions:
   contents: write
 
 env:
-  # NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/1720215802/ddev-linux-amd64.zip"
-  # Allow ddev get to use a github token to prevent rate limiting by tests
+  # Allow ddev get to use a GitHub token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -37,54 +36,14 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-    - name: Environment setup
-      run: |
-        brew tap kaos/shell && brew install bats-core bats-assert bats-support jq mkcert
-        mkcert -install
-
-    - name: Use ddev stable
-      if: matrix.ddev_version == 'stable'
-      run: brew install ddev/ddev/ddev
-
-    - name: Use ddev edge
-      if: matrix.ddev_version == 'edge'
-      run: brew install ddev/ddev-edge/ddev
-
-    - name: Use ddev HEAD
-      if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD ddev/ddev/ddev
-
-    - name: Use ddev PR
-      if: matrix.ddev_version == 'PR'
-      run: |
-        curl -sSL -o ddev_linux.zip ${NIGHTLY_DDEV_PR_URL}
-        unzip ddev_linux.zip
-        mv ddev /usr/local/bin/ddev && chmod +x /usr/local/bin/ddev
-
-    - name: Download docker images
-      run: mkdir junk && pushd junk && ddev config --auto && ddev debug download-images >/dev/null
-
-    - name: tmate debugging session
-      uses: mxschmitt/action-tmate@v3
+    - uses: ddev/github-action-add-on-test@v1
       with:
-        limit-access-to-actor: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-      if: github.event.inputs.debug_enabled == 'true'
-
-    - name: tests
-      run: bats tests
-
-    # keepalive-workflow adds a dummy commit if there's no other action here, keeps
-    # GitHub from turning off tests after 60 days
-    - uses: gautamkrishnar/keepalive-workflow@v1
-      if: matrix.ddev_version == 'stable'
+        ddev_version: "stable"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        addon_repository: ${{ env.GITHUB_REPOSITORY }}
+        addon_ref: ${{ env.GITHUB_REF }}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,7 +26,7 @@ health_checks() {
   # Make sure `ddev phpmyadmin` works
   DDEV_DEBUG=true run ddev phpmyadmin
   assert_success
-  assert_output "FULLURL https://${PROJNAME}.ddev.site:8037"
+  assert_output --partial "FULLURL https://${PROJNAME}.ddev.site:8037"
 }
 
 teardown() {


### PR DESCRIPTION
## The Issue

* Minor test failures complaining about ddev being built without instrumentation.
* Convert to use the github-action-add-on-test

