### PR TITLE
Mention 'ddev phpmyadmin' in readme and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,6 @@ In DDEV v1.22+ PhpMyAdmin will not be provided by default, but can be added with
 
 `ddev get ddev/ddev-phpmyadmin`
 
+You can run PhpMyAdmin easily with the command `ddev phpmyadmin` after installing this add-on.
+
 **Contributed and maintained by [@rfay](https://github.com/rfay)**

--- a/install.yaml
+++ b/install.yaml
@@ -14,4 +14,6 @@ post_install_actions:
     if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
       printf "#ddev-generated\nservices:\n  phpmyadmin:\n    ports:\n      - 8036:80\n" > docker-compose.phpmyadmin-norouter.yaml
     fi
+  - | 
+    echo "You can now use 'ddev phpmyadmin' to launch PhpMyAdmin"
 


### PR DESCRIPTION
## The Issue

The readme didn't say anything about `ddev phpmyadmin`