### PR TITLE
Add `ddev start` for the host command

### DIFF
--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -5,6 +5,11 @@
 ## Usage: phpmyadmin
 ## Example: "ddev phpmyadmin"
 
+if [ "${DDEV_PROJECT_STATUS-running}" != "running" ]; then
+  echo "Project ${DDEV_PROJECT} is not running, starting it"
+  ddev start
+fi
+
 DDEV_PHPMYADMIN_PORT=8036
 DDEV_PHPMYADMIN_HTTPS_PORT=8037
 


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5603

## How This PR Solves The Issue

In the next release of DDEV, there will be no automatic project start when the host command is executed, so this PR adds the necessary `ddev start` here.
