### PR TITLE
⏫ bump github-action-add-on-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ defaults:
 
 # This is required for "gautamkrishnar/keepalive-workflow"
 permissions:
-  contents: write
+  actions: write
 
 env:
   # Allow ddev get to use a GitHub token to prevent rate limiting by tests
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: "stable"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR bumps the github-action-add-on-test worflow.

The main benefit being the removal of dummy commits which prevent automated testing from being disabled.

@see https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0