### PR TITLE
Add early exit on `ddev start` error

### DIFF
--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -5,9 +5,16 @@
 ## Usage: phpmyadmin
 ## Example: "ddev phpmyadmin"
 
-if [ "${DDEV_PROJECT_STATUS-running}" != "running" ]; then
+if [ "${DDEV_PROJECT_STATUS-running}" != "running" ] && [ -z "$no_recursion" ]; then
   echo "Project ${DDEV_PROJECT} is not running, starting it"
   ddev start
+  start_exit_code=$?
+  if [ $start_exit_code -ne 0 ]; then
+    exit $start_exit_code
+  fi
+  # run this script again, as the environment is updated after "ddev start"
+  no_recursion=true ddev "$(basename "$0")" "$@"
+  exit $?
 fi
 
 DDEV_PHPMYADMIN_PORT=8036


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/5976

## How This PR Solves The Issue

Do not run the script on `ddev start` error.
Recursion check is not really needed here, but I copied it anyway.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

