### PR TITLE
Pin phpmyadmin to 5.2.0, fixes #17

### DIFF
--- a/docker-compose.phpmyadmin.yaml
+++ b/docker-compose.phpmyadmin.yaml
@@ -2,7 +2,7 @@
 services:
   phpmyadmin:
     container_name: ddev-${DDEV_SITENAME}-phpmyadmin
-    image: phpmyadmin:5
+    image: phpmyadmin:5.2.0
     working_dir: "/root"
     restart: "no"
     labels:


### PR DESCRIPTION
## The Issue

- #17

phpMyAdmin was updated 9 days ago to 5.2.1, something has changed upstream.

## How This PR Solves The Issue

Change the version from `5` to `5.2.0`.

## Manual Testing Instructions

1. Click Open in Gitpod https://ddev.github.io/ddev-gitpod-launcher/
2. Wait for the website to be ready.
3. `ddev get https://github.com/ddev/ddev-phpmyadmin/tarball/20240715_stasadev_pin_the_image && ddev restart`
4. Stop the workspace here https://gitpod.io/workspaces
5. Start it again, run `ddev start`, it should work.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

