### PR TITLE
Fix `ddev phpmyadmin` for Gitpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,4 @@ You can run phpMyAdmin easily with the command after installing this add-on:
 ddev phpmyadmin
 ```
 
-> [!TIP]
-> For Gitpod: The `ddev phpmyadmin` command can open a blank page in preview mode, open the link in a new browser tab/window to make it work.
-
 **Contributed and maintained by [@rfay](https://github.com/rfay)**

--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -8,7 +8,7 @@
 DDEV_PHPMYADMIN_PORT=8036
 DDEV_PHPMYADMIN_HTTPS_PORT=8037
 if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
-    if [ -n "${GITPOD_WORKSPACE_ID:-}" ]; then
+    if [ -n "${GITPOD_WORKSPACE_ID:-}" ] && [ -z "${DDEV_DEBUG:-}" ]; then
         # "gp preview" opens a blank page for PhpMyAdmin, use "xdg-open" instead
         xdg-open "$(DDEV_DEBUG=true ddev launch :$DDEV_PHPMYADMIN_PORT | grep "FULLURL" | awk '{print $2}')"
     else

--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -8,8 +8,8 @@
 DDEV_PHPMYADMIN_PORT=8036
 DDEV_PHPMYADMIN_HTTPS_PORT=8037
 if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
-    if [ -n "${GITPOD_WORKSPACE_ID:-}" ] && [ -z "${DDEV_DEBUG:-}" ]; then
-        # "gp preview" opens a blank page for PhpMyAdmin, use "xdg-open" instead
+    # Gitpod: "gp preview" opens a blank page for PhpMyAdmin, use "xdg-open" instead
+    if [ "${OSTYPE:-}" = "linux-gnu" ] && [ -n "${GITPOD_WORKSPACE_ID:-}" ] && [ -z "${DDEV_DEBUG:-}" ]; then
         xdg-open "$(DDEV_DEBUG=true ddev launch :$DDEV_PHPMYADMIN_PORT | grep "FULLURL" | awk '{print $2}')"
     else
         ddev launch :$DDEV_PHPMYADMIN_PORT

--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -8,7 +8,12 @@
 DDEV_PHPMYADMIN_PORT=8036
 DDEV_PHPMYADMIN_HTTPS_PORT=8037
 if [ ${DDEV_PRIMARY_URL%://*} = "http" ] || [ -n "${GITPOD_WORKSPACE_ID:-}" ] || [ "${CODESPACES:-}" = "true" ]; then
-    ddev launch :$DDEV_PHPMYADMIN_PORT
+    if [ -n "${GITPOD_WORKSPACE_ID:-}" ]; then
+        # "gp preview" opens a blank page for PhpMyAdmin, use "xdg-open" instead
+        xdg-open "$(DDEV_DEBUG=true ddev launch :$DDEV_PHPMYADMIN_PORT | grep "FULLURL" | awk '{print $2}')"
+    else
+        ddev launch :$DDEV_PHPMYADMIN_PORT
+    fi
 else
     ddev launch :$DDEV_PHPMYADMIN_HTTPS_PORT
 fi


### PR DESCRIPTION
## The Issue

The `ddev phpmyadmin` command can open a blank page in preview mode, open the link in a new browser tab/window to make it work.

## How This PR Solves The Issue

Uses `xdg-open` for PhpMyAdmin URL.

## Manual Testing Instructions

In Gitpod:

https://ddev.github.io/ddev-gitpod-launcher/

```
ddev get https://github.com/ddev/ddev-phpmyadmin/tarball/20241003_stasadev_fix_gitpod_command
ddev restart
ddev phpmyadmin
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

