### PR TITLE
feat: Docker image override with env, update tests, constraint v1.24.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
   schedule:
-  - cron: '25 09 * * *'
+  - cron: '01 07 * * *'
 
   workflow_dispatch:
     inputs:
@@ -15,35 +15,28 @@ on:
         required: false
         default: false
 
-defaults:
-  run:
-    shell: bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow"
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
   actions: write
 
-env:
-  # Allow ddev get to use a GitHub token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   tests:
-    defaults:
-      run:
-        shell: bash
-
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: "stable"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}

--- a/README.md
+++ b/README.md
@@ -1,37 +1,52 @@
-[![tests](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-phpmyadmin)](https://github.com/ddev/ddev-phpmyadmin/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-phpmyadmin)](https://github.com/ddev/ddev-phpmyadmin/releases/latest)
 
-# ddev-phpmyadmin <!-- omit in toc -->
+# DDEV phpMyAdmin
 
-* [What is ddev-phpmyadmin?](#what-is-ddev-phpmyadmin)
+## Overview
 
-## What is ddev-phpmyadmin?
+[phpMyAdmin](https://www.phpmyadmin.net/) is a free and open source administration tool for MySQL and MariaDB.
 
-This add-on provides a phpMyAdmin service for [DDEV](https://github.com/ddev/ddev/).
+This add-on integrates phpMyAdmin into your [DDEV](https://ddev.com/) project.
 
-In DDEV v1.22+ phpMyAdmin is not provided by default, but it can be added with this add-on.
+## Installation
 
-For DDEV v1.23.5 or above run
-
-```sh
+```bash
 ddev add-on get ddev/ddev-phpmyadmin
-```
-
-For earlier versions of DDEV run
-
-```sh
-ddev get ddev/ddev-phpmyadmin
-```
-
-Then restart your project
-
-```sh
 ddev restart
 ```
 
-You can run phpMyAdmin easily with the command after installing this add-on:
+After installation, make sure to commit the `.ddev` directory to version control.
+
+## Usage
+
+| Command | Description |
+| ------- | ----------- |
+| `ddev phpmyadmin` | Open phpMyAdmin in your browser (`https://<project>.ddev.site:8037`) |
+| `ddev describe` | View service status and used ports for phpMyAdmin |
+| `ddev logs -s phpmyadmin` | Check phpMyAdmin logs |
+
+## Advanced Customization
+
+To change the Docker image:
 
 ```sh
-ddev phpmyadmin
+ddev dotenv set .ddev/.env.phpmyadmin --phpmyadmin-docker-image=phpmyadmin:5
+ddev add-on get ddev/ddev-phpmyadmin
+ddev restart
 ```
 
-**Contributed and maintained by [@rfay](https://github.com/rfay)**
+Make sure to commit the `.ddev/.env.phpmyadmin` file to version control.
+
+All customization options (use with caution):
+
+| Variable | Flag | Default |
+| -------- | ---- | ------- |
+| `PHPMYADMIN_DOCKER_IMAGE` | `--phpmyadmin-docker-image` | `phpmyadmin:5` |
+
+## Credits
+
+**Contributed by [@rfay](https://github.com/rfay)**
+
+**Maintained by the [DDEV team](https://ddev.com/support-ddev/)**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
 [![tests](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-phpmyadmin/actions/workflows/tests.yml?query=branch%3Amain)
 [![last commit](https://img.shields.io/github/last-commit/ddev/ddev-phpmyadmin)](https://github.com/ddev/ddev-phpmyadmin/commits)
 [![release](https://img.shields.io/github/v/release/ddev/ddev-phpmyadmin)](https://github.com/ddev/ddev-phpmyadmin/releases/latest)

--- a/docker-compose.phpmyadmin.yaml
+++ b/docker-compose.phpmyadmin.yaml
@@ -2,26 +2,26 @@
 services:
   phpmyadmin:
     container_name: ddev-${DDEV_SITENAME}-phpmyadmin
-    image: phpmyadmin:5.2.0
+    image: ${PHPMYADMIN_DOCKER_IMAGE:-phpmyadmin:5}
     working_dir: "/root"
     restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
     volumes:
-    - ".:/mnt/ddev_config"
-    - "ddev-global-cache:/mnt/ddev-global-cache"
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
     expose:
       - "80"
     environment:
-    - PMA_USER=root
-    - PMA_PASSWORD=root
-    - PMA_HOST=db
-    - PMA_PORT=3306
-    - VIRTUAL_HOST=$DDEV_HOSTNAME
-    - UPLOAD_LIMIT=4000M
-    - HTTP_EXPOSE=8036:80
-    - HTTPS_EXPOSE=8037:80
+      - PMA_USER=root
+      - PMA_PASSWORD=root
+      - PMA_HOST=db
+      - PMA_PORT=3306
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - UPLOAD_LIMIT=4000M
+      - HTTP_EXPOSE=8036:80
+      - HTTPS_EXPOSE=8037:80
     healthcheck:
       interval: 120s
       timeout: 2s

--- a/install.yaml
+++ b/install.yaml
@@ -1,26 +1,25 @@
-#ddev-generated
-
 name: phpmyadmin
 
 project_files:
-- docker-compose.phpmyadmin.yaml
-- docker-compose.phpmyadmin_norouter.yaml
-- commands/host/phpmyadmin
+  - docker-compose.phpmyadmin.yaml
+  - docker-compose.phpmyadmin_norouter.yaml
+  - commands/host/phpmyadmin
 
 pre_install_actions:
-  # Ensure we're on DDEV 1.23+. It's need for the `phpmyadmin` command (launch by port).
   - |
-    #ddev-nodisplay
-    #ddev-description:Checking DDEV version
-    (ddev debug capabilities | grep corepack >/dev/null) || (echo "Please upgrade DDEV to v1.23+ to use this add-on." && false)
+    #ddev-description:Check for db service
+    if ddev debug configyaml 2>/dev/null | grep omit_containers | grep -q db; then
+      echo "Unable to install the add-on because no db service was found"
+      exit 1
+    fi
+
+ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
   - |
     #ddev-description:If router disabled, directly expose port
-    #
     if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
       printf "#ddev-generated\nservices:\n  phpmyadmin:\n    ports:\n      - 8036:80\n" > docker-compose.phpmyadmin_norouter.yaml
     fi
   - |
     echo "You can now use 'ddev phpmyadmin' to launch PhpMyAdmin"
-

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,28 +1,55 @@
+#!/usr/bin/env bats
+
+# Bats is a testing framework for Bash
+# Documentation https://bats-core.readthedocs.io/en/stable/
+# Bats libraries documentation https://github.com/ztombol/bats-docs
+
+# For local tests, install bats-core, bats-assert, bats-file, bats-support
+# And run this in the add-on root directory:
+#   bats ./tests/test.bats
+# To exclude release tests:
+#   bats ./tests/test.bats --filter-tags '!release'
+# For debugging:
+#   bats ./tests/test.bats --show-output-of-passing-tests --verbose-run --print-output-on-failure
+
 setup() {
   set -eu -o pipefail
-  brew_prefix=$(brew --prefix)
-  load "${brew_prefix}/lib/bats-support/load.bash"
-  load "${brew_prefix}/lib/bats-assert/load.bash"
 
-  export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/test-phpmyadmin
-  mkdir -p $TESTDIR
-  export PROJNAME=test-phpmyadmin
-  export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
+  # Override this variable for your add-on:
+  export GITHUB_REPO=ddev/ddev-phpmyadmin
+
+  TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+  export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"
+  bats_load_library bats-assert
+  bats_load_library bats-file
+  bats_load_library bats-support
+
+  export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
+  export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  mkdir -p ~/tmp
+  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  export DDEV_NONINTERACTIVE=true
+  export DDEV_NO_INSTRUMENTATION=true
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
   cd "${TESTDIR}"
-  ddev config --project-name=${PROJNAME}
-  ddev config --omit-containers=dba >/dev/null 2>&1 || true
-  ddev start -y >/dev/null 2>&1
+  run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site
+  assert_success
+  run ddev start -y
+  assert_success
 }
 
 health_checks() {
-  set +u # bats-assert has unset variables so turn off unset check
-  # ddev restart is required because we have done `ddev get` on a new service
-  run ddev restart
-  assert_success
   # Make sure we can hit the 8037 port successfully
-  curl -s -I -f  https://${PROJNAME}.ddev.site:8037 >/tmp/curlout.txt
+  run curl -sfI https://${PROJNAME}.ddev.site:8037
+  assert_success
+  assert_output --partial "HTTP/2 200"
+  assert_output --partial "server: Apache"
+  assert_output --partial "x-powered-by: PHP"
+
+  run curl -sf https://${PROJNAME}.ddev.site:8037
+  assert_success
+  assert_output --partial "phpMyAdmin"
+
   # Make sure `ddev phpmyadmin` works
   DDEV_DEBUG=true run ddev phpmyadmin
   assert_success
@@ -31,38 +58,53 @@ health_checks() {
 
 teardown() {
   set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {
   set -eu -o pipefail
-  cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null 2>&1
-  ddev mutagen sync >/dev/null 2>&1
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
   health_checks
 }
 
-
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
-  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ddev/ddev-phpmyadmin with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ddev/ddev-phpmyadmin >/dev/null 2>&1
-  ddev restart >/dev/null 2>&1
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${GITHUB_REPO}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
   health_checks
 }
 
-@test "install from directory with nonstandard port" {
+@test "install from directory with nonstandard port and .env.phpmyadmin" {
   set -eu -o pipefail
-  cd ${TESTDIR}
-  ddev config --router-http-port=8080 --router-https-port=8443
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR} >/dev/null 2>&1
-  ddev mutagen sync >/dev/null 2>&1
+
+  run ddev config --router-http-port=8080 --router-https-port=8443
+  assert_success
+
+  run ddev dotenv set .ddev/.env.phpmyadmin --phpmyadmin-docker-image=phpmyadmin:5.2.2
+  assert_success
+  assert_file_exist .ddev/.env.phpmyadmin
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
   health_checks
 }
-
-


### PR DESCRIPTION
## The Issue

We should be able to override phpmyadmin image with `.ddev/.env.phpmyadmin`

## How This PR Solves The Issue

- Adds `--phpmyadmin-docker-image` flag.
- Uses tag `5` instead of `5.2.0` - there was some bug with 5.2.1, and newer phpMyAdmin didn't work with Gitpod (see #18), I rechecked it again, the current 5.2.2 works fine with Gitpod.
- Updates README.md with new badges.
- Updates tests, adds more health checks.
- Adds version constraint v1.24.3
- Adds check for `db` service before installing the add-on.

## Manual Testing Instructions

Review https://github.com/ddev/ddev-phpmyadmin/blob/20250411_stasadev_upstream_updates/README.md

```bash
ddev add-on get https://github.com/ddev/ddev-phpmyadmin/tarball/20250411_stasadev_upstream_updates
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
