### PR TITLE
Change shebang to use env for bash, fixes #27

### DIFF
--- a/commands/host/phpmyadmin
+++ b/commands/host/phpmyadmin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## #ddev-generated: If you want to edit and own this file, remove this line.
 ## Description: Launch a browser with PhpMyAdmin


### PR DESCRIPTION
## The Issue

- #27 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Changes the shebang line to use the env program to determine the user's path to bash.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
ddev restart
```

## Automated Testing Overview

No changes to existing tests as this would work with existing test.

## Release/Deployment Notes

No expected ramifications to other code