### PR TITLE
fix: add healthcheck test command, fixes #29

### DIFF
--- a/docker-compose.phpmyadmin.yaml
+++ b/docker-compose.phpmyadmin.yaml
@@ -23,6 +23,7 @@ services:
       - HTTP_EXPOSE=8036:80
       - HTTPS_EXPOSE=8037:80
     healthcheck:
+      test: ["CMD-SHELL", "true"]
       interval: 120s
       timeout: 2s
       retries: 1


### PR DESCRIPTION
## The Issue

- #29 

Podman requires a `healthcheck.test` command will fail with the following error if it's not defined:

```
Error response from daemon: fill out specgen: must define a healthcheck command for all healthchecks
```

**Note:** The `test` command is a required part of the [Docker Compose spec for `healthcheck`](https://docs.docker.com/reference/compose-file/services/#healthcheck), but different Docker provider tools may choose to treat it as ignored/skip if not present, or to treat it as a fatal issue.

## How This PR Solves The Issue

This PR adds a simple "always healthy" shell return for the `test` command.

It meets 3 goals:

1. Satisfies Podman's `test` command requirement
2. Respects an earlier issue as to why the `test` command was removed in the first place, where an accurate healthcheck can cause the container to report healthy way too slowly (#2 )
3. Leaves the option to add in a different `test` command later

(Can confirm, when testing a couple of different variant son an accurate healthcheck: the response time was all over the place and very inconsistent. Sometimes it came back within half a second, other times it took over 80 seconds. Not too sure why!)

Another alternative would be to disable the healthcheck altogether, if it's not needed for local development with DDEV. This is also following the Docker Compose spec, and Podman will accept it:

```yaml
healthcheck:
  test: ["NONE"]
```

## Manual Testing Instructions

1. Install and configure Podman as the Docker provider for DDEV
4. Create a new DDEV project
5. Install the proposed version of the add-on and restart DDEV:

```bash
ddev add-on get https://github.com/coolbrewed/ddev-phpmyadmin/tarball/bugfix/add-healthcheck-command
ddev restart
```

The phpMyAdmin project container should successfully build and run without the error.

## Automated Testing Overview

This PR doesn't change the add-on's build or runtime behavior, just , so no tests need to be updated or added.

## Release/Deployment Notes

This change should not impact any other code or deployment steps. 

It's worth noting that setting the `healthcheck` key here should override any healthcheck later defined by the official phpMyAdmin Docker build itself, so it is good to keep it rather than omit in order to avoid being surprised by suddenly long healthcheck times.
